### PR TITLE
Implement set-price command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-test
+# Price Tracker
+
+This is a minimal price tracker example. Products are stored in `products.json` in the repository root.
+
+## Commands
+
+Run commands using `python -m main <command>`.
+
+### Set Price
+
+```
+python -m main set-price <product_url> <price>
+```
+
+Updates the stored price for the product without fetching it.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+import argparse
+from price_tracker.tracker import get_tracker
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Price Tracker")
+    sub = parser.add_subparsers(dest="cmd")
+
+    set_price_p = sub.add_parser("set-price", help="Set the price of a product")
+    set_price_p.add_argument("url", help="Product URL")
+    set_price_p.add_argument("price", type=float, help="New price")
+
+    args = parser.parse_args()
+
+    if args.cmd == "set-price":
+        tracker = get_tracker()
+        product = tracker.store.find_by_url(args.url)
+        if not product:
+            raise SystemExit("Product not found")
+        tracker.store.set_price(product, args.price)
+        print(f"Set price for {product.url} to {args.price}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/price_tracker/products.py
+++ b/price_tracker/products.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, asdict, field
+from typing import List, Optional
+import json
+import os
+
+@dataclass
+class Product:
+    name: str
+    url: str
+    price_history: List[float] = field(default_factory=list)
+    last_price: Optional[float] = None
+
+class ProductStore:
+    def __init__(self, path: str = "products.json"):
+        self.path = path
+        self.products: List[Product] = []
+        self.load()
+
+    def load(self) -> None:
+        if os.path.exists(self.path):
+            with open(self.path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.products = [Product(**p) for p in data]
+
+    def save(self) -> None:
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump([asdict(p) for p in self.products], fh, indent=2)
+
+    def find_by_url(self, url: str) -> Optional[Product]:
+        for p in self.products:
+            if p.url == url:
+                return p
+        return None
+
+    def update_price(self, product: Product, price: float) -> None:
+        product.price_history.append(price)
+        product.last_price = price
+        self.save()
+
+    def set_price(self, product: Product, price: float) -> None:
+        """Set product price without fetching.
+
+        Updates price_history and last_price similarly to update_price.
+        """
+        self.update_price(product, price)

--- a/price_tracker/tracker.py
+++ b/price_tracker/tracker.py
@@ -1,0 +1,12 @@
+from .products import ProductStore
+
+class Tracker:
+    def __init__(self, store: ProductStore | None = None):
+        self.store = store or ProductStore()
+
+    def save(self) -> None:
+        self.store.save()
+
+
+def get_tracker() -> Tracker:
+    return Tracker()


### PR DESCRIPTION
## Summary
- add a minimal price_tracker package
- implement set_price helper in ProductStore
- create CLI with `set-price` subcommand
- document command usage in README
- remove compiled artifacts

## Testing
- `python -m main -h`
- `python -m main set-price http://example.com 9.99` (fails because product doesn't exist)


------
https://chatgpt.com/codex/tasks/task_e_68405c19684c83319d829f2758ebc42c