### PR TITLE
Fix paused attribute comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Domyślnie lista produktów znajduje się w pliku `products.json`. Moduły sklep
 - Dodawanie i usuwanie produktów odbywa się z poziomu listy produktów. Każdy wiersz ma przycisk **Delete**.
 - Ceny można sprawdzić ręcznie przez link **Check prices now**.
 - Automatyczne sprawdzanie można tymczasowo wstrzymać lub wznowić przyciskami **Pause checking** i **Resume checking**.
+  Stan wstrzymania przechowywany jest w atrybucie ``PriceTracker.paused``.

--- a/price_tracker/tracker.py
+++ b/price_tracker/tracker.py
@@ -16,6 +16,7 @@ class PriceTracker:
         self.shops: Dict[str, ShopModule] = {}
         self.interval = interval
         self.email = email
+        # flag used by ``run`` to control automatic price checks
         self.paused = False
 
     def register_shop(self, name: str, shop: ShopModule) -> None:


### PR DESCRIPTION
## Summary
- add comment clarifying paused flag in `PriceTracker`
- note paused attribute in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684134f6342083318713a6e42c27a28b