### PR TITLE
Implement shop management via web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ python3 web.py
 ```
 
 Domyślnie lista produktów znajduje się w pliku `products.json`. Moduły sklepów znajdują się w katalogu `price_tracker/shops` i dziedziczą po klasie `ShopModule`.
+Konfiguracja sklepów przechowywana jest w pliku `shops.json` i może być modyfikowana z poziomu interfejsu WWW.
 
 ### Zarządzanie przez Web GUI
 
 - Dodawanie i usuwanie produktów odbywa się z poziomu listy produktów. Każdy wiersz ma przycisk **Delete**.
+- Dodawanie, edycja (łącznie ze zmianą nazwy) oraz usuwanie sklepów dostępne są poprzez link **Manage shops**.
 - Ceny można sprawdzić ręcznie przez link **Check prices now**.
 - Automatyczne sprawdzanie można tymczasowo wstrzymać lub wznowić przyciskami **Pause checking** i **Resume checking**.
   Stan wstrzymania przechowywany jest w atrybucie ``PriceTracker.paused``.

--- a/main.py
+++ b/main.py
@@ -1,12 +1,8 @@
 from price_tracker.tracker import PriceTracker
-from price_tracker.shops.shop_a import ShopA
-from price_tracker.shops.shop_b import ShopB
 
 
 def main() -> None:
-    tracker = PriceTracker('products.json', interval=3600)
-    tracker.register_shop('shopa', ShopA())
-    tracker.register_shop('shopb', ShopB())
+    tracker = PriceTracker('products.json', interval=3600, shops_path='shops.json')
 
     # Example of adding a product
     # tracker.add_product('Example Product', 'http://example.com/product', 'shopa')

--- a/price_tracker/shop_store.py
+++ b/price_tracker/shop_store.py
@@ -1,0 +1,56 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+@dataclass
+class ShopDef:
+    name: str
+    selector: str
+
+class ShopStore:
+    """Persist shop definitions to a JSON file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.shops: Dict[str, ShopDef] = {}
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            self.shops = {}
+            return
+        data = json.loads(self.path.read_text())
+        self.shops = {
+            name: ShopDef(name=name, selector=sel)
+            for name, sel in data.get('shops', {}).items()
+        }
+
+    def save(self) -> None:
+        data = {'shops': {name: shop.selector for name, shop in self.shops.items()}}
+        self.path.write_text(json.dumps(data, indent=2))
+
+    def add(self, shop: ShopDef) -> None:
+        self.shops[shop.name] = shop
+        self.save()
+
+    def update(self, shop: ShopDef) -> None:
+        self.shops[shop.name] = shop
+        self.save()
+
+    def remove(self, name: str) -> None:
+        if name not in self.shops:
+            raise ValueError(f'Shop {name} not found')
+        del self.shops[name]
+        self.save()
+
+    def rename(self, old_name: str, new_name: str) -> None:
+        """Rename a shop definition."""
+        if old_name not in self.shops:
+            raise ValueError(f'Shop {old_name} not found')
+        if new_name in self.shops and new_name != old_name:
+            raise ValueError(f'Shop {new_name} already exists')
+        shop = self.shops.pop(old_name)
+        shop.name = new_name
+        self.shops[new_name] = shop
+        self.save()

--- a/price_tracker/shops/__init__.py
+++ b/price_tracker/shops/__init__.py
@@ -1,0 +1,1 @@
+from .generic import GenericShop

--- a/price_tracker/shops/generic.py
+++ b/price_tracker/shops/generic.py
@@ -1,0 +1,20 @@
+import requests
+from bs4 import BeautifulSoup
+
+from .base import ShopModule
+
+class GenericShop(ShopModule):
+    """Shop module defined by a CSS selector."""
+
+    def __init__(self, selector: str) -> None:
+        self.selector = selector
+
+    def get_price(self, url: str) -> float:
+        response = requests.get(url)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, 'html.parser')
+        element = soup.select_one(self.selector)
+        if element is None:
+            raise ValueError(f'Price element not found using selector {self.selector}')
+        price_text = element.text.strip()
+        return float(price_text.replace('$', '').replace(',', ''))

--- a/shops.json
+++ b/shops.json
@@ -1,0 +1,6 @@
+{
+  "shops": {
+    "shopa": "span.price",
+    "shopb": "div#product-price"
+  }
+}

--- a/web.py
+++ b/web.py
@@ -2,13 +2,9 @@ from threading import Thread
 from flask import Flask, request, redirect, url_for, render_template_string
 
 from price_tracker.tracker import PriceTracker
-from price_tracker.shops.shop_a import ShopA
-from price_tracker.shops.shop_b import ShopB
 
 app = Flask(__name__)
-tracker = PriceTracker('products.json', interval=3600)
-tracker.register_shop('shopa', ShopA())
-tracker.register_shop('shopb', ShopB())
+tracker = PriceTracker('products.json', interval=3600, shops_path='shops.json')
 
 # start background price checking
 def start_background_tracker():
@@ -20,6 +16,7 @@ INDEX_TEMPLATE = """
 <!doctype html>
 <title>Price Tracker</title>
 <h1>Tracked Products</h1>
+<p><a href="{{ url_for('list_shops') }}">Manage shops</a></p>
 <ul>
   {% for p in products %}
   <li>
@@ -53,6 +50,44 @@ INDEX_TEMPLATE = """
 </p>
 """
 
+SHOPS_TEMPLATE = """
+<!doctype html>
+<title>Shops</title>
+<h1>Registered Shops</h1>
+<ul>
+  {% for name, selector in shops.items() %}
+  <li>{{ name }} - {{ selector }}
+      <a href="{{ url_for('edit_shop_form', name=name) }}">Edit</a>
+      <form method="post" action="{{ url_for('delete_shop', name=name) }}" style="display:inline">
+        <button type="submit">Delete</button>
+      </form>
+  </li>
+  {% endfor %}
+</ul>
+<h2>Add Shop</h2>
+<form method="post" action="{{ url_for('add_shop') }}">
+  Name: <input name="name"><br>
+  Selector: <input name="selector"><br>
+  <button type="submit">Add</button>
+</form>
+<p><a href="{{ url_for('index') }}">Back</a></p>
+"""
+
+EDIT_SHOP_TEMPLATE = """
+<!doctype html>
+<title>Edit Shop</title>
+<h1>Edit {{ original_name }}</h1>
+<form method="post" action="{{ url_for('update_shop', original_name=original_name) }}">
+  Name: <input name="name" value="{{ original_name }}"><br>
+  CSS selector: <input name="selector" value="{{ selector }}"><br>
+  <button type="submit">Save</button>
+</form>
+<form method="post" action="{{ url_for('delete_shop', name=original_name) }}">
+  <button type="submit">Delete shop</button>
+</form>
+<p><a href="{{ url_for('list_shops') }}">Back to shops</a></p>
+"""
+
 @app.route('/')
 def index():
     paused = getattr(tracker, 'paused', False)
@@ -64,6 +99,44 @@ def index():
         shops=tracker.shops.keys(),
         paused=paused,
     )
+
+
+@app.route('/shops')
+def list_shops():
+    shops = {name: s.selector for name, s in tracker.shop_store.shops.items()}
+    return render_template_string(SHOPS_TEMPLATE, shops=shops)
+
+
+@app.route('/shops/add', methods=['POST'])
+def add_shop():
+    tracker.add_shop(request.form['name'], request.form['selector'])
+    return redirect(url_for('list_shops'))
+
+
+@app.route('/shops/edit/<name>')
+def edit_shop_form(name):
+    shop = tracker.shop_store.shops.get(name)
+    if not shop:
+        return redirect(url_for('list_shops'))
+    return render_template_string(EDIT_SHOP_TEMPLATE, original_name=name, selector=shop.selector)
+
+
+@app.route('/shops/update/<original_name>', methods=['POST'])
+def update_shop(original_name):
+    new_name = request.form['name']
+    selector = request.form['selector']
+    if new_name != original_name:
+        tracker.rename_shop(original_name, new_name)
+        tracker.update_shop(new_name, selector)
+    else:
+        tracker.update_shop(original_name, selector)
+    return redirect(url_for('list_shops'))
+
+
+@app.route('/shops/delete/<name>', methods=['POST'])
+def delete_shop(name):
+    tracker.remove_shop(name)
+    return redirect(url_for('list_shops'))
 
 @app.route('/add', methods=['POST'])
 def add_product():


### PR DESCRIPTION
## Summary
- create `ShopStore` with JSON persistence
- add `GenericShop` for configurable CSS-based shops
- load shop configs from `shops.json` in `PriceTracker`
- extend `web.py` with routes and templates for adding/editing shops
- update CLI example and README for new shop management capabilities
- support renaming and deleting shops via web interface

## Testing
- `python3 -m py_compile main.py web.py price_tracker/*.py price_tracker/shops/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684168753950833196e20ef23716e355