### PR TITLE
Fix selector detection ignoring script tags

### DIFF
--- a/web.py
+++ b/web.py
@@ -195,7 +195,13 @@ def detect_selector():
 
     soup = BeautifulSoup(resp.text, 'html.parser')
     pattern = re.compile(r'\d+[\.,]\d+\s*(?:zł|pln|eur|€|usd|\$)?', re.I)
-    element = soup.find(string=pattern)
+
+    # Ignore matches located inside <script> or <style> tags
+    element = None
+    for el in soup.find_all(string=pattern):
+        if el.parent.name not in ('script', 'style'):
+            element = el
+            break
     if not element:
         return '', 404
     elem = element.parent


### PR DESCRIPTION
## Summary
- avoid using prices found in script or style tags when detecting the selector

## Testing
- `python -m py_compile web.py`


------
https://chatgpt.com/codex/tasks/task_e_68417ff852848331b33dfe4249132f8d