### PR TITLE
Improve price parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ Konfiguracja sklepów przechowywana jest w pliku `shops.json` i może być modyf
 ### Format cen
 
 Aplikacja obsługuje ceny zapisywane w formacie europejskim, np. `1 234,56 zł`.
-Funkcja `parse_price` usuwa symbole walut, spacje oddzielające tysiące i
-zamienia przecinek na kropkę, dzięki czemu poprawnie działa zarówno dla
-notacji amerykańskiej, jak i europejskiej.
+Funkcja `parse_price` usuwa symbole walut oraz separatory tysięcy (spacje lub
+kropki), zamienia przecinek na kropkę i usuwa ewentualne znaki interpunkcyjne
+po wartości. Dzięki temu poprawnie działa zarówno dla notacji amerykańskiej,
+jak i europejskiej.
 
 ### Zarządzanie przez Web GUI
 

--- a/price_tracker/shops/generic.py
+++ b/price_tracker/shops/generic.py
@@ -17,6 +17,12 @@ def parse_price(text: str) -> float:
     cleaned = cleaned.replace("\xa0", "").replace(" ", "")
     cleaned = cleaned.replace(",", ".")
     cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    cleaned = cleaned.strip(".")
+    if cleaned.count(".") > 1:
+        last = cleaned.rfind(".")
+        cleaned = cleaned[:last].replace(".", "") + cleaned[last:]
+    if not cleaned or cleaned == ".":
+        raise ValueError(f"Could not parse price: {text}")
     return float(cleaned)
 
 class GenericShop(ShopModule):

--- a/tests/test_parse_price.py
+++ b/tests/test_parse_price.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from price_tracker.shops.generic import parse_price
+
+@pytest.mark.parametrize('text,expected', [
+    ('29.99,', 29.99),
+    ('29,99 zł', 29.99),
+    ('1 234,56 zł', 1234.56),
+    ('1.234,56 zł', 1234.56),
+    ('1 234.56$', 1234.56),
+])
+def test_parse_price(text, expected):
+    assert parse_price(text) == expected


### PR DESCRIPTION
## Summary
- fix trailing punctuation and dot thousand separators in `parse_price`
- document improved price parsing in README
- add regression tests for parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418d3997808331a95b17e0ae05a27e