### PR TITLE
Improve price detection from JSON-LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Przykładowa aplikacja w Pythonie pozwalająca na monitorowanie cen w różnych 
 
 ## Instalacja zależności
 
-Wymagane biblioteki są zdefiniowane w pliku `requirements.txt`. Przed uruchomieniem aplikacji zainstaluj je poleceniem:
+Wymagane biblioteki (m.in. Flask, requests i BeautifulSoup) są zdefiniowane w pliku `requirements.txt`. Przed uruchomieniem aplikacji zainstaluj je poleceniem:
 
 ```bash
 pip install -r requirements.txt
@@ -28,9 +28,11 @@ Konfiguracja sklepów przechowywana jest w pliku `shops.json` i może być modyf
 ### Format cen
 
 Aplikacja obsługuje ceny zapisywane w formacie europejskim, np. `1 234,56 zł`.
-Funkcja `parse_price` usuwa symbole walut, spacje oddzielające tysiące i
-zamienia przecinek na kropkę, dzięki czemu poprawnie działa zarówno dla
-notacji amerykańskiej, jak i europejskiej.
+Funkcja `parse_price` usuwa symbole walut oraz separatory tysięcy (spacje lub
+kropki), zamienia przecinek na kropkę i usuwa ewentualne znaki interpunkcyjne
+po wartości. Dzięki temu poprawnie działa zarówno dla notacji amerykańskiej,
+jak i europejskiej. Dodatkowo aplikacja potrafi pobrać cenę zapisaną w
+skryptach JSON‑LD (`<script type="application/ld+json">`).
 
 ### Zarządzanie przez Web GUI
 

--- a/price_tracker/shops/generic.py
+++ b/price_tracker/shops/generic.py
@@ -1,4 +1,5 @@
 import re
+import json
 import requests
 from bs4 import BeautifulSoup
 
@@ -17,7 +18,36 @@ def parse_price(text: str) -> float:
     cleaned = cleaned.replace("\xa0", "").replace(" ", "")
     cleaned = cleaned.replace(",", ".")
     cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
+    cleaned = cleaned.strip(".")
+    if cleaned.count(".") > 1:
+        last = cleaned.rfind(".")
+        cleaned = cleaned[:last].replace(".", "") + cleaned[last:]
+    if not cleaned or cleaned == ".":
+        raise ValueError(f"Could not parse price: {text}")
     return float(cleaned)
+
+
+def _find_price_in_json(data):
+    """Recursively search for price fields in a JSON object."""
+    if isinstance(data, dict):
+        for key in (
+            "price",
+            "current_price",
+            "lowPrice",
+            "highPrice",
+        ):
+            if key in data and isinstance(data[key], (str, int, float)):
+                return data[key]
+        for value in data.values():
+            found = _find_price_in_json(value)
+            if found is not None:
+                return found
+    elif isinstance(data, list):
+        for item in data:
+            found = _find_price_in_json(item)
+            if found is not None:
+                return found
+    return None
 
 class GenericShop(ShopModule):
     """Shop module defined by a CSS selector."""
@@ -30,10 +60,8 @@ class GenericShop(ShopModule):
         response.raise_for_status()
         soup = BeautifulSoup(response.text, 'html.parser')
         element = soup.select_one(self.selector)
-        if element is None:
-            raise ValueError(f'Price element not found using selector {self.selector}')
 
-        price_text = (element.text or '').strip()
+        price_text = (element.text or '').strip() if element else ''
         if price_text:
             try:
                 price = parse_price(price_text)
@@ -44,14 +72,29 @@ class GenericShop(ShopModule):
 
         # Fallback: some shops store the price in data attributes like
         # "data-product-gtm" as JSON with fields such as "current_price".
-        for attr in ('data-product-gtm', 'data-product', 'data-gtm'):
-            attr_val = element.get(attr)
-            if not attr_val:
-                continue
-            match = re.search(r'"current_price"\s*:\s*"?([0-9.,]+)"?', attr_val)
-            if not match:
-                match = re.search(r'"price"\s*:\s*"?([0-9.,]+)"?', attr_val)
-            if match:
-                return parse_price(match.group(1))
+        if element:
+            for attr in ('data-product-gtm', 'data-product', 'data-gtm'):
+                attr_val = element.get(attr)
+                if not attr_val:
+                    continue
+                match = re.search(r'"current_price"\s*:\s*"?([0-9.,]+)"?', attr_val)
+                if not match:
+                    match = re.search(r'"price"\s*:\s*"?([0-9.,]+)"?', attr_val)
+                if match:
+                    return parse_price(match.group(1))
 
-        raise ValueError('Price not found in element')
+        # Fallback to JSON-LD scripts
+        for script in soup.find_all('script', type='application/ld+json'):
+            if not script.string:
+                continue
+            try:
+                data = json.loads(script.string)
+            except Exception:
+                continue
+            val = _find_price_in_json(data)
+            if val is not None:
+                return parse_price(str(val))
+
+        if element is None:
+            raise ValueError(f'Price element not found using selector {self.selector}')
+        raise ValueError('Price not found in element or JSON-LD')

--- a/tests/test_generic_shop.py
+++ b/tests/test_generic_shop.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import requests
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from price_tracker.shops.generic import GenericShop
+
+
+class MockResponse:
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def make_get(html):
+    def _get(url):
+        return MockResponse(html)
+    return _get
+
+
+def test_price_from_text(monkeypatch):
+    html = "<span class='price'>29,99 zł</span>"
+    monkeypatch.setattr(requests, 'get', make_get(html))
+    shop = GenericShop('span.price')
+    assert shop.get_price('http://example.com') == 29.99
+
+
+def test_price_from_data_attribute(monkeypatch):
+    html = "<div class='p' data-product-gtm='{\"current_price\": \"123,45\"}'></div>"
+    monkeypatch.setattr(requests, 'get', make_get(html))
+    shop = GenericShop('div.p')
+    assert shop.get_price('http://example.com') == 123.45
+
+
+def test_price_from_jsonld(monkeypatch):
+    html = (
+        "<script type='application/ld+json'>{"
+        "\"offers\": {\"price\": 49.99, \"priceCurrency\": \"PLN\"}}"
+        "</script>"
+    )
+    monkeypatch.setattr(requests, 'get', make_get(html))
+    # Selector not found, should still parse from JSON-LD
+    shop = GenericShop('span.price')
+    assert shop.get_price('http://example.com') == 49.99

--- a/tests/test_parse_price.py
+++ b/tests/test_parse_price.py
@@ -1,0 +1,16 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from price_tracker.shops.generic import parse_price
+
+@pytest.mark.parametrize('text,expected', [
+    ('29.99,', 29.99),
+    ('29,99 zł', 29.99),
+    ('1 234,56 zł', 1234.56),
+    ('1.234,56 zł', 1234.56),
+    ('1 234.56$', 1234.56),
+])
+def test_parse_price(text, expected):
+    assert parse_price(text) == expected

--- a/web.py
+++ b/web.py
@@ -1,10 +1,11 @@
 from threading import Thread
 import re
+import json
 import requests
 from bs4 import BeautifulSoup
 from flask import Flask, request, redirect, url_for, render_template_string, jsonify
 
-from price_tracker.shops.generic import parse_price
+from price_tracker.shops.generic import parse_price, _find_price_in_json
 
 from price_tracker.tracker import PriceTracker
 
@@ -213,21 +214,41 @@ def detect_selector():
 
     # Ignore matches located inside <script> or <style> tags
     element = None
+    price_value = None
     for el in soup.find_all(string=pattern):
         if el.parent.name not in ('script', 'style'):
+            try:
+                price_value = parse_price(str(el))
+            except Exception:
+                continue
             element = el
             break
-    if not element:
-        return '', 404
-    elem = element.parent
-    selector = elem.name
-    if elem.get('id'):
-        selector += f"#{elem.get('id')}"
-    elif elem.get('class'):
-        selector += '.' + '.'.join(elem.get('class'))
 
-    price_value = parse_price(str(element))
-    return jsonify({'selector': selector, 'price': price_value})
+    if element is not None:
+        elem = element.parent
+        selector = elem.name
+        if elem.get('id'):
+            selector += f"#{elem.get('id')}"
+        elif elem.get('class'):
+            selector += '.' + '.'.join(elem.get('class'))
+        return jsonify({'selector': selector, 'price': price_value})
+
+    # Fallback to JSON-LD scripts
+    for script in soup.find_all('script', type='application/ld+json'):
+        if not script.string:
+            continue
+        try:
+            data = json.loads(script.string)
+        except Exception:
+            continue
+        val = _find_price_in_json(data)
+        if val is not None:
+            return jsonify({
+                'selector': "script[type='application/ld+json']",
+                'price': parse_price(str(val))
+            })
+
+    return '', 404
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
## Summary
- parse price from JSON-LD scripts
- support JSON-LD in generic shop and selector detection
- add tests for GenericShop price extraction
- mention Flask dependency and JSON-LD support in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68418d3997808331a95b17e0ae05a27e