### PR TITLE
Improve JSON-LD selector handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Przykładowa aplikacja w Pythonie pozwalająca na monitorowanie cen w różnych 
 
 ## Instalacja zależności
 
-Wymagane biblioteki są zdefiniowane w pliku `requirements.txt`. Przed uruchomieniem aplikacji zainstaluj je poleceniem:
+Wymagane biblioteki (m.in. Flask, requests i BeautifulSoup) są zdefiniowane w pliku `requirements.txt`. Przed uruchomieniem aplikacji zainstaluj je poleceniem:
 
 ```bash
 pip install -r requirements.txt
@@ -28,9 +28,19 @@ Konfiguracja sklepów przechowywana jest w pliku `shops.json` i może być modyf
 ### Format cen
 
 Aplikacja obsługuje ceny zapisywane w formacie europejskim, np. `1 234,56 zł`.
-Funkcja `parse_price` usuwa symbole walut, spacje oddzielające tysiące i
-zamienia przecinek na kropkę, dzięki czemu poprawnie działa zarówno dla
-notacji amerykańskiej, jak i europejskiej.
+Funkcja `parse_price` usuwa symbole walut oraz separatory tysięcy (spacje lub
+kropki). Rozpoznaje również przypadki, gdy część dziesiętna jest oddzielona
+od wartości głównej spacją (np. `29 99 zł`). W takich sytuacjach łączy oba
+fragmenty w jedną liczbę. Następnie przecinek zamienia na kropkę i usuwa
+ewentualne znaki interpunkcyjne po wartości. Dzięki temu poprawnie działa
+zarówno dla notacji amerykańskiej, jak i europejskiej. Dodatkowo aplikacja
+potrafi pobrać cenę zapisaną w
+  skryptach JSON‑LD (`<script type="application/ld+json">`).
+  Wyszukiwanie w takich skryptach wykonywane jest priorytetowo,
+  dzięki czemu unikamy przypadkowego dopasowania liczb niezwiązanych z ceną.
+  Jeżeli selektor wskazuje bezpośrednio na taki tag `<script>`,
+  zawartość jest interpretowana jako JSON, a nie zwykły tekst,
+  co zapobiega odczytywaniu numerów identyfikacyjnych jako ceny.
 
 ### Zarządzanie przez Web GUI
 

--- a/price_tracker/shops/generic.py
+++ b/price_tracker/shops/generic.py
@@ -1,4 +1,5 @@
 import re
+import json
 import requests
 from bs4 import BeautifulSoup
 
@@ -14,10 +15,49 @@ def parse_price(text: str) -> float:
     """
     cleaned = text.strip()
     cleaned = re.sub(r"(?i)(zł|pln|eur|euro|usd|\$|€|gbp|£)", "", cleaned)
-    cleaned = cleaned.replace("\xa0", "").replace(" ", "")
-    cleaned = cleaned.replace(",", ".")
-    cleaned = re.sub(r"[^0-9.\-]", "", cleaned)
-    return float(cleaned)
+    cleaned = cleaned.replace("\xa0", " ")
+    match = re.search(r"-?\d[\d .,]*\d", cleaned)
+    if not match:
+        raise ValueError(f"Could not parse price: {text}")
+
+    number = match.group(0)
+    if " " in number:
+        parts = number.split()
+        if len(parts) == 2 and len(parts[1]) == 2 and parts[0].isdigit() and parts[1].isdigit():
+            number = parts[0] + "." + parts[1]
+        else:
+            number = "".join(parts)
+    number = number.replace(" ", "").replace(",", ".")
+    number = re.sub(r"[^0-9.\-]", "", number)
+    number = number.strip(".")
+    if number.count(".") > 1:
+        last = number.rfind(".")
+        number = number[:last].replace(".", "") + number[last:]
+
+    return float(number)
+
+
+def _find_price_in_json(data):
+    """Recursively search for price fields in a JSON object."""
+    if isinstance(data, dict):
+        for key in (
+            "price",
+            "current_price",
+            "lowPrice",
+            "highPrice",
+        ):
+            if key in data and isinstance(data[key], (str, int, float)):
+                return data[key]
+        for value in data.values():
+            found = _find_price_in_json(value)
+            if found is not None:
+                return found
+    elif isinstance(data, list):
+        for item in data:
+            found = _find_price_in_json(item)
+            if found is not None:
+                return found
+    return None
 
 class GenericShop(ShopModule):
     """Shop module defined by a CSS selector."""
@@ -30,10 +70,25 @@ class GenericShop(ShopModule):
         response.raise_for_status()
         soup = BeautifulSoup(response.text, 'html.parser')
         element = soup.select_one(self.selector)
-        if element is None:
-            raise ValueError(f'Price element not found using selector {self.selector}')
 
-        price_text = (element.text or '').strip()
+        # If selector points to a JSON-LD <script>, parse it as JSON first
+        if (
+            element
+            and element.name == 'script'
+            and element.get('type') == 'application/ld+json'
+        ):
+            if element.string:
+                try:
+                    data = json.loads(element.string)
+                    val = _find_price_in_json(data)
+                    if val is not None:
+                        return parse_price(str(val))
+                except Exception:
+                    pass
+            price_text = ''
+        else:
+            price_text = (element.text or '').strip() if element else ''
+
         if price_text:
             try:
                 price = parse_price(price_text)
@@ -44,14 +99,29 @@ class GenericShop(ShopModule):
 
         # Fallback: some shops store the price in data attributes like
         # "data-product-gtm" as JSON with fields such as "current_price".
-        for attr in ('data-product-gtm', 'data-product', 'data-gtm'):
-            attr_val = element.get(attr)
-            if not attr_val:
-                continue
-            match = re.search(r'"current_price"\s*:\s*"?([0-9.,]+)"?', attr_val)
-            if not match:
-                match = re.search(r'"price"\s*:\s*"?([0-9.,]+)"?', attr_val)
-            if match:
-                return parse_price(match.group(1))
+        if element:
+            for attr in ('data-product-gtm', 'data-product', 'data-gtm'):
+                attr_val = element.get(attr)
+                if not attr_val:
+                    continue
+                match = re.search(r'"current_price"\s*:\s*"?([0-9.,]+)"?', attr_val)
+                if not match:
+                    match = re.search(r'"price"\s*:\s*"?([0-9.,]+)"?', attr_val)
+                if match:
+                    return parse_price(match.group(1))
 
-        raise ValueError('Price not found in element')
+        # Fallback to JSON-LD scripts
+        for script in soup.find_all('script', type='application/ld+json'):
+            if not script.string:
+                continue
+            try:
+                data = json.loads(script.string)
+            except Exception:
+                continue
+            val = _find_price_in_json(data)
+            if val is not None:
+                return parse_price(str(val))
+
+        if element is None:
+            raise ValueError(f'Price element not found using selector {self.selector}')
+        raise ValueError('Price not found in element or JSON-LD')

--- a/tests/test_generic_shop.py
+++ b/tests/test_generic_shop.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import requests
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from price_tracker.shops.generic import GenericShop
+
+
+class MockResponse:
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def make_get(html):
+    def _get(url):
+        return MockResponse(html)
+    return _get
+
+
+def test_price_from_text(monkeypatch):
+    html = "<span class='price'>29,99 zł</span>"
+    monkeypatch.setattr(requests, 'get', make_get(html))
+    shop = GenericShop('span.price')
+    assert shop.get_price('http://example.com') == 29.99
+
+
+def test_price_from_data_attribute(monkeypatch):
+    html = "<div class='p' data-product-gtm='{\"current_price\": \"123,45\"}'></div>"
+    monkeypatch.setattr(requests, 'get', make_get(html))
+    shop = GenericShop('div.p')
+    assert shop.get_price('http://example.com') == 123.45
+
+
+def test_price_from_jsonld(monkeypatch):
+    html = (
+        "<script type='application/ld+json'>{"
+        "\"offers\": {\"price\": 49.99, \"priceCurrency\": \"PLN\"}}"
+        "</script>"
+    )
+    monkeypatch.setattr(requests, 'get', make_get(html))
+    # Selector not found, should still parse from JSON-LD
+    shop = GenericShop('span.price')
+    assert shop.get_price('http://example.com') == 49.99
+
+
+def test_price_when_selector_points_to_jsonld(monkeypatch):
+    html = (
+        "<script type='application/ld+json'>"
+        '{"offers": {"price": 77.55, "priceCurrency": "PLN"}}'
+        "</script>"
+    )
+    monkeypatch.setattr(requests, 'get', make_get(html))
+    shop = GenericShop("script[type='application/ld+json']")
+    assert shop.get_price('http://example.com') == 77.55

--- a/tests/test_parse_price.py
+++ b/tests/test_parse_price.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from price_tracker.shops.generic import parse_price
+
+@pytest.mark.parametrize('text,expected', [
+    ('29.99,', 29.99),
+    ('29,99 zł', 29.99),
+    ('1 234,56 zł', 1234.56),
+    ('1.234,56 zł', 1234.56),
+    ('1 234.56$', 1234.56),
+    ('K-Beauty 2.0', 2.0),
+    ('29 99 zł', 29.99),
+])
+def test_parse_price(text, expected):
+    assert parse_price(text) == expected

--- a/web.py
+++ b/web.py
@@ -1,10 +1,11 @@
 from threading import Thread
 import re
+import json
 import requests
 from bs4 import BeautifulSoup
 from flask import Flask, request, redirect, url_for, render_template_string, jsonify
 
-from price_tracker.shops.generic import parse_price
+from price_tracker.shops.generic import parse_price, _find_price_in_json
 
 from price_tracker.tracker import PriceTracker
 
@@ -209,25 +210,49 @@ def detect_selector():
         return str(exc), 400
 
     soup = BeautifulSoup(resp.text, 'html.parser')
+
+    # First try JSON-LD scripts which often contain the exact price
+    for script in soup.find_all('script', type='application/ld+json'):
+        if not script.string:
+            continue
+        try:
+            data = json.loads(script.string)
+        except Exception:
+            continue
+        val = _find_price_in_json(data)
+        if val is not None:
+            return jsonify({
+                'selector': "script[type='application/ld+json']",
+                'price': parse_price(str(val))
+            })
+
     pattern = re.compile(r'\d+[\.,]\d+\s*(?:zł|pln|eur|€|usd|\$)?', re.I)
 
     # Ignore matches located inside <script> or <style> tags
     element = None
+    price_value = None
     for el in soup.find_all(string=pattern):
-        if el.parent.name not in ('script', 'style'):
-            element = el
-            break
-    if not element:
-        return '', 404
-    elem = element.parent
-    selector = elem.name
-    if elem.get('id'):
-        selector += f"#{elem.get('id')}"
-    elif elem.get('class'):
-        selector += '.' + '.'.join(elem.get('class'))
+        if el.parent.name in ('script', 'style'):
+            continue
+        try:
+            price_value = parse_price(str(el))
+        except Exception:
+            continue
+        if price_value < 0:
+            continue
+        element = el
+        break
 
-    price_value = parse_price(str(element))
-    return jsonify({'selector': selector, 'price': price_value})
+    if element is not None:
+        elem = element.parent
+        selector = elem.name
+        if elem.get('id'):
+            selector += f"#{elem.get('id')}"
+        elif elem.get('class'):
+            selector += '.' + '.'.join(elem.get('class'))
+        return jsonify({'selector': selector, 'price': price_value})
+
+    return '', 404
 
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
## Summary
- parse JSON when selector points directly at a JSON-LD `<script>`
- clarify README about how JSON-LD selectors are treated
- test `GenericShop` with a JSON-LD selector

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418d3997808331a95b17e0ae05a27e