### PR TITLE
Add SMTP test email option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ skryptach JSON‑LD (`<script type="application/ld+json">`).
 - Automatyczne sprawdzanie można tymczasowo wstrzymać lub wznowić przyciskami **Pause checking** i **Resume checking**.
   Stan wstrzymania przechowywany jest w atrybucie ``PriceTracker.paused``.
 
+### Konfiguracja SMTP
+
+Parametry serwera SMTP używanego do wysyłania powiadomień można zmienić
+bezpośrednio z poziomu interfejsu WWW. W menu na górze dostępny jest link
+**SMTP settings**, który prowadzi do formularza umożliwiającego podanie adresu
+serwera, portu oraz danych uwierzytelniających. Na stronie dostępny jest też
+formularz umożliwiający wysłanie wiadomości testowej na wybrany adres,
+dzięki czemu można sprawdzić poprawność konfiguracji.
+
 ### Rozwiązywanie problemów
 
 Jeśli podczas uruchamiania interfejsu WWW pojawi się błąd

--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ from price_tracker.tracker import PriceTracker
 
 
 def main() -> None:
-    tracker = PriceTracker('products.json', interval=3600, shops_path='shops.json')
+    tracker = PriceTracker('products.json', interval=3600,
+                          shops_path='shops.json', smtp_path='smtp.json')
 
     # Example of adding a product
     # tracker.add_product('Example Product', 'http://example.com/product', 'shopa')

--- a/price_tracker/smtp_config.py
+++ b/price_tracker/smtp_config.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class SmtpConfig:
+    server: str = 'localhost'
+    port: int = 25
+    username: Optional[str] = None
+    password: Optional[str] = None
+
+
+class SmtpConfigStore:
+    """Persist SMTP configuration to a JSON file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.config = SmtpConfig()
+        self.load()
+
+    def load(self) -> None:
+        if self.path.exists():
+            data = json.loads(self.path.read_text())
+            self.config = SmtpConfig(
+                server=data.get('server', 'localhost'),
+                port=data.get('port', 25),
+                username=data.get('username'),
+                password=data.get('password'),
+            )
+
+    def save(self) -> None:
+        self.path.write_text(json.dumps(vars(self.config), indent=2))
+
+    def update(self, config: SmtpConfig) -> None:
+        self.config = config
+        self.save()

--- a/price_tracker/tracker.py
+++ b/price_tracker/tracker.py
@@ -8,15 +8,18 @@ from .shops.generic import GenericShop
 from .products import Product, ProductStore
 from .notification import send_email
 from .shops.base import ShopModule
+from .smtp_config import SmtpConfig, SmtpConfigStore
 
 
 class PriceTracker:
     """Main application class."""
 
     def __init__(self, store_path: str, interval: int = 3600,
-                 email: str | None = None, shops_path: str = 'shops.json') -> None:
+                 email: str | None = None, shops_path: str = 'shops.json',
+                 smtp_path: str = 'smtp.json') -> None:
         self.store = ProductStore(Path(store_path))
         self.shop_store = ShopStore(Path(shops_path))
+        self.smtp_store = SmtpConfigStore(Path(smtp_path))
         self.shops: Dict[str, ShopModule] = {}
         self.interval = interval
         self.email = email
@@ -83,6 +86,28 @@ class PriceTracker:
         """Remove a tracked product by URL."""
         self.store.remove(url)
 
+    def update_smtp_config(self, server: str, port: int,
+                           username: str | None,
+                           password: str | None) -> None:
+        """Update SMTP settings used for email notifications."""
+        cfg = SmtpConfig(server=server, port=port,
+                         username=username or None,
+                         password=password or None)
+        self.smtp_store.update(cfg)
+
+    def send_test_email(self, recipient: str) -> None:
+        """Send a test email using current SMTP settings."""
+        cfg = self.smtp_store.config
+        send_email(
+            recipient,
+            'Test email from Price Tracker',
+            'This is a test message to confirm SMTP configuration.',
+            smtp_server=cfg.server,
+            smtp_port=cfg.port,
+            username=cfg.username,
+            password=cfg.password,
+        )
+
     def check_prices(self) -> None:
         for product in self.store.products:
             shop = GenericShop(product.selector)
@@ -104,7 +129,16 @@ class PriceTracker:
         msg = (f'Price drop for {product.name}: {old} -> {new}\n'
                f'URL: {product.url}')
         if self.email:
-            send_email(self.email, f'Price drop: {product.name}', msg)
+            cfg = self.smtp_store.config
+            send_email(
+                self.email,
+                f'Price drop: {product.name}',
+                msg,
+                smtp_server=cfg.server,
+                smtp_port=cfg.port,
+                username=cfg.username,
+                password=cfg.password,
+            )
         else:
             print(msg)
 

--- a/smtp.json
+++ b/smtp.json
@@ -1,0 +1,6 @@
+{
+  "server": "localhost",
+  "port": 25,
+  "username": null,
+  "password": null
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -15,6 +15,9 @@
             <li class="nav-item">
               <a class="nav-link" href="{{ url_for('list_shops') }}">Manage shops</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('smtp_settings') }}">SMTP settings</a>
+            </li>
           </ul>
         </div>
       </div>

--- a/templates/smtp_settings.html
+++ b/templates/smtp_settings.html
@@ -1,0 +1,41 @@
+{% extends 'layout.html' %}
+{% block title %}SMTP Settings{% endblock %}
+{% block content %}
+  <h1 class="mb-4">SMTP Settings</h1>
+  {% if status == 'saved' %}
+    <div class="alert alert-success">Settings saved.</div>
+  {% elif status == 'sent' %}
+    <div class="alert alert-success">Test email sent.</div>
+  {% elif status == 'error' %}
+    <div class="alert alert-danger">Failed to send test email.</div>
+  {% endif %}
+  <form method="post" action="{{ url_for('update_smtp_settings') }}">
+    <div class="mb-3">
+      <label class="form-label">Server</label>
+      <input name="server" value="{{ server }}" class="form-control">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Port</label>
+      <input name="port" value="{{ port }}" class="form-control" type="number">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Username</label>
+      <input name="username" value="{{ username }}" class="form-control">
+    </div>
+    <div class="mb-3">
+      <label class="form-label">Password</label>
+      <input name="password" value="{{ password }}" class="form-control" type="password">
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+  <hr>
+  <h2 class="h5">Send test email</h2>
+  <form method="post" action="{{ url_for('send_test_email_route') }}">
+    <div class="mb-3">
+      <label class="form-label">Recipient</label>
+      <input name="recipient" class="form-control" type="email">
+    </div>
+    <button type="submit" class="btn btn-secondary">Send test</button>
+  </form>
+  <p class="mt-3"><a class="btn btn-outline-secondary" href="{{ url_for('index') }}">Back</a></p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow sending test email from SMTP settings page
- add `send_test_email` helper method on `PriceTracker`
- expose new route in Flask web UI
- document how to send a test message

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684244d5497083319ad73bffa283df15